### PR TITLE
Ensure tolerance is not random

### DIFF
--- a/frref.py
+++ b/frref.py
@@ -60,7 +60,7 @@ def frref(A, TOL=None, TYPE=''):
         if TOL is None:
             # Prior commit had TOL default to 1e-6
             # TOL = max(m,n)*eps(class(A))*norm(A,'inf')
-            TOL = max(m, n)*np.spacing(type(A)(1))*np.linalg.norm(A, np.inf)
+            TOL = max(m, n)*np.finfo(A.dtype).eps*np.linalg.norm(A, np.inf)
 
     # Non-Sparse
     # ----------------------------------------------------------


### PR DESCRIPTION
The way tolerance is currently calculated results in a random value for "eps". 

This can be tested by:

```python
A = np.random.random(10)
```
```
array([0.68375657, 0.44136403, 0.70564723, 0.80721841, 0.82241247,
       0.5919192 , 0.8746679 , 0.52398925, 0.9871945 , 0.14101868])
```

```python
np.spacing(type(A)(1))
```
```
array([2.77555756e-17])
```

```python
np.spacing(type(A)(1))
```
```
array([6.16297582e-33])
```

This obviously results in a random tolerance. The proposed change ensures that the correct eps value is used and is deterministic.